### PR TITLE
Update appveyor.yml

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,6 +18,13 @@ dotnet_csproj:
   assembly_version: $(GitVersion_AssemblySemVer)
   file_version: $(GitVersion_AssemblySemVer)
   informational_version: $(GitVersion_FullSemVer)
+  
+assembly_info:
+   patch: true
+   file: '**\AssemblyInfo.*'
+   assembly_version: $(GitVersion_AssemblySemVer)
+   assembly_file_version: $(GitVersion_AssemblySemVer)
+   assembly_informational_version: $(GitVersion_FullSemVer)
 
 on_failure:
   - ps: 7z a "WorkingTree.zip"


### PR DESCRIPTION
Update appveyor script to version the windows packages correctly. Currently `phirSOFT.SettingsService.Prism` is versioned as 1.0.0 which is wrong. This patch should resolve that issue.