### PR TITLE
Hotfix/0.2.4 - Bug in ReadOnlySettingsStack

### DIFF
--- a/phirSOFT.SettingsService.Test/phirSOFT.SettingsService.Test.csproj
+++ b/phirSOFT.SettingsService.Test/phirSOFT.SettingsService.Test.csproj
@@ -7,6 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="NSubstitute" Version="4.2.1" />
+    <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.12" />
     <PackageReference Include="nunit" Version="3.11.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.12.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />

--- a/phirSOFT.SettingsService/ReadOnlySettingsStack.cs
+++ b/phirSOFT.SettingsService/ReadOnlySettingsStack.cs
@@ -43,8 +43,15 @@ namespace phirSOFT.SettingsService
         /// <inheritdoc/>
         public async Task<object> GetSettingAsync(string key, Type type)
         {
-            return (await TryGetSettingService(key).ConfigureAwait(false))?.GetSettingAsync(key, type) ??
-                   throw new KeyNotFoundException();
+            IReadOnlySettingsService settingsService = await TryGetSettingService(key).ConfigureAwait(false);
+
+            if (settingsService == null)
+            {
+                throw new KeyNotFoundException();
+            }
+
+            return await settingsService.GetSettingAsync(key, type).ConfigureAwait(false);
+
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
# Fix ReadOnlySettingsStack

The Task returned by `ReadOnlySettingsStack.GetSettingAsync()` does not
return the settings value, but the task, that will return the settings
value.