### PR TITLE
Hotfix/0.2.4 - Fix #52

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.2.4] - 2020-03-12
+- Fix Bug #52: `ReadOnlySettingsStack` does not await Settings Value
+
 ## [0.2.3] - 2019-09-14
 ### Added
 - Add Icon to `phirSOFT.SettingsService` nuget package.

--- a/azure-pipeline.yml
+++ b/azure-pipeline.yml
@@ -20,7 +20,7 @@ variables:
 steps:
   - task: GitVersion@5
     inputs:
-      runtime: 'core'
+      runtime: "core"
   - task: UseDotNet@2
     displayName: "Use .Net Core sdk "
     inputs:
@@ -53,10 +53,10 @@ steps:
   - task: DotNetCoreCLI@2
     displayName: "dotnet push"
     inputs:
-      command: 'push'
-      packagesToPush: '$(Build.ArtifactStagingDirectory)/*.nupkg'
-      nuGetFeedType: 'internal'
-      publishVstsFeed: '388aae20-7808-45ea-998a-2f8a20859841/a32b6034-468f-431e-84b4-5b66854b4bf0'
+      command: "push"
+      packagesToPush: "$(Build.ArtifactStagingDirectory)/*.nupkg"
+      nuGetFeedType: "internal"
+      publishVstsFeed: "388aae20-7808-45ea-998a-2f8a20859841/a32b6034-468f-431e-84b4-5b66854b4bf0"
 
   - task: NuGetToolInstaller@1
     condition: and(succeeded(), eq(variables['Release.Publish'], 'True'))

--- a/azure-pipeline.yml
+++ b/azure-pipeline.yml
@@ -18,8 +18,9 @@ variables:
   Release.Publish: $[and(ne(variables['Build.Reason'], 'PullRequest'), or(startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/hotfix/'), eq(variables['Build.SourceBranch'], 'refs/heads/master')))]
 
 steps:
-  - task: gittools.gitversion.gitversion-task.GitVersion@5
-    displayName: GitVersion'
+  - task: GitVersion@5
+    inputs:
+      runtime: 'core'
   - task: UseDotNet@2
     displayName: "Use .Net Core sdk "
     inputs:
@@ -52,9 +53,10 @@ steps:
   - task: DotNetCoreCLI@2
     displayName: "dotnet push"
     inputs:
-      command: push
-      publishVstsFeed: "0a220c4b-5ab8-47bf-baf0-fdfb139b70c4/faf9ee1b-b648-43cb-9a50-c60ae34d9adf"
-      includesymbols: true
+      command: 'push'
+      packagesToPush: '$(Build.ArtifactStagingDirectory)/*.nupkg'
+      nuGetFeedType: 'internal'
+      publishVstsFeed: '388aae20-7808-45ea-998a-2f8a20859841/a32b6034-468f-431e-84b4-5b66854b4bf0'
 
   - task: NuGetToolInstaller@1
     condition: and(succeeded(), eq(variables['Release.Publish'], 'True'))
@@ -82,5 +84,5 @@ steps:
       tag: "$(GitVersion.FullSemVer)"
       title: "$(GitVersion.FullSemVer)"
       releaseNotesFile: "ReleaseNotes.md"
-      isPreRelease: $(Release.IsPrerelease)
+      isPreRelease: eq(variables['Release.IsPrerelease'], 'True')
       compareWith: "lastFullRelease"

--- a/phirSOFT.SettingsService.Test/ReadOnlySettingsStackTests.cs
+++ b/phirSOFT.SettingsService.Test/ReadOnlySettingsStackTests.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Threading.Tasks;
+using NSubstitute;
+using NUnit.Framework;
+using phirSOFT.SettingsService.Abstractions;
+
+namespace phirSOFT.SettingsService.Test
+{
+    [TestFixture]
+    public class ReadOnlySettingsStackTests
+    {
+        private const string Key1 = "key1";
+
+        [Test]
+        public async Task GetSettingAsync_ReturnsValue()
+        {
+            // Arrange
+            var readOnlySettingsStack = new ReadOnlySettingsStack {CreateReadOnlySettingsService()};
+            Type type = typeof(string);
+
+            // Act
+            object result = await readOnlySettingsStack.GetSettingAsync(
+                Key1,
+                type);
+
+            // Assert
+            Assert.IsInstanceOf<string>(result);
+            Assert.AreEqual("value1", result);
+        }
+
+        [SetUp]
+        public void SetUp()
+        {
+        }
+
+        private static IReadOnlySettingsService CreateReadOnlySettingsService()
+        {
+            IReadOnlySettingsService settingsServiceMock = Substitute.For<IReadOnlySettingsService>();
+
+            settingsServiceMock.IsRegisteredAsync(Arg.Is(Key1)).Returns(true);
+            settingsServiceMock.GetSettingAsync(Arg.Is(Key1), Arg.Is(typeof(string))).Returns("value1");
+            return settingsServiceMock;
+        }
+    }
+}

--- a/phirSOFT.SettingsService.Test/ReadOnlySettingsStackTests.cs
+++ b/phirSOFT.SettingsService.Test/ReadOnlySettingsStackTests.cs
@@ -15,7 +15,7 @@ namespace phirSOFT.SettingsService.Test
         public async Task GetSettingAsync_ReturnsValue()
         {
             // Arrange
-            var readOnlySettingsStack = new ReadOnlySettingsStack {CreateReadOnlySettingsService()};
+            var readOnlySettingsStack = new ReadOnlySettingsStack { CreateReadOnlySettingsService() };
             Type type = typeof(string);
 
             // Act

--- a/phirSOFT.SettingsService.Test/phirSOFT.SettingsService.Test.csproj
+++ b/phirSOFT.SettingsService.Test/phirSOFT.SettingsService.Test.csproj
@@ -7,6 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="NSubstitute" Version="4.2.1" />
+    <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.12" />
     <PackageReference Include="nunit" Version="3.11.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.12.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />

--- a/phirSOFT.SettingsService/ReadOnlySettingsStack.cs
+++ b/phirSOFT.SettingsService/ReadOnlySettingsStack.cs
@@ -43,8 +43,15 @@ namespace phirSOFT.SettingsService
         /// <inheritdoc/>
         public async Task<object> GetSettingAsync(string key, Type type)
         {
-            return (await TryGetSettingService(key).ConfigureAwait(false))?.GetSettingAsync(key, type) ??
-                   throw new KeyNotFoundException();
+            IReadOnlySettingsService settingsService = await TryGetSettingService(key).ConfigureAwait(false);
+
+            if (settingsService == null)
+            {
+                throw new KeyNotFoundException();
+            }
+
+            return await settingsService.GetSettingAsync(key, type).ConfigureAwait(false);
+
         }
 
         /// <inheritdoc/>

--- a/phirSOFT.SettingsService/ReadOnlySettingsStack.cs
+++ b/phirSOFT.SettingsService/ReadOnlySettingsStack.cs
@@ -51,7 +51,6 @@ namespace phirSOFT.SettingsService
             }
 
             return await settingsService.GetSettingAsync(key, type).ConfigureAwait(false);
-
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
The Task returned by `ReadOnlySettingsStack.GetSettingAsync()` does not return the settings value, but the task, that will return the settings value.