### PR TITLE
Replace Jetbrains Annotations with Nullable Annotations

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,6 @@
+<Project>
+  <PropertyGroup>
+    <Nullable>enable</Nullable>
+    <LangVersion>8.0</LangVersion>
+  </PropertyGroup>
+</Project>

--- a/SettingsService.sln
+++ b/SettingsService.sln
@@ -10,6 +10,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Ci-Pipeline", "Ci-Pipeline", "{8210544E-8E15-4933-AEE1-DC348656773D}"
 	ProjectSection(SolutionItems) = preProject
 		azure-pipeline.yml = azure-pipeline.yml
+		Directory.Build.props = Directory.Build.props
 		GitVersion.yml = GitVersion.yml
 		global.json = global.json
 	EndProjectSection

--- a/phirSOFT.SettingsService.Abstractions/IReadOnlySettingsService.cs
+++ b/phirSOFT.SettingsService.Abstractions/IReadOnlySettingsService.cs
@@ -5,14 +5,12 @@
 
 using System;
 using System.Threading.Tasks;
-using JetBrains.Annotations;
 
 namespace phirSOFT.SettingsService.Abstractions
 {
     /// <summary>
     ///     Provides an interface for readonly settings.
     /// </summary>
-    [PublicAPI]
     public interface IReadOnlySettingsService
     {
         /// <summary>
@@ -21,14 +19,13 @@ namespace phirSOFT.SettingsService.Abstractions
         /// <param name="key">The key of the setting.</param>
         /// <param name="type">The type of the setting to retrieve.</param>
         /// <returns>The value of the setting, if its present in this service.</returns>
-        [ItemCanBeNull]
-        Task<object> GetSettingAsync([NotNull] string key, [NotNull] Type type);
+        Task<object?> GetSettingAsync(string key, Type type);
 
         /// <summary>
         ///     Determines whether a setting is present in this service.
         /// </summary>
         /// <param name="key">The key of the setting.</param>
         /// <returns>True, if the setting can be retrieved, false if not.</returns>
-        Task<bool> IsRegisteredAsync([NotNull] string key);
+        Task<bool> IsRegisteredAsync(string key);
     }
 }

--- a/phirSOFT.SettingsService.Abstractions/ISettingsService.cs
+++ b/phirSOFT.SettingsService.Abstractions/ISettingsService.cs
@@ -5,7 +5,6 @@
 
 using System;
 using System.Threading.Tasks;
-using JetBrains.Annotations;
 
 namespace phirSOFT.SettingsService.Abstractions
 {
@@ -18,7 +17,6 @@ namespace phirSOFT.SettingsService.Abstractions
     /// <remarks>
     ///     Though it might not required, most implementations will only accept serializable settings type.
     /// </remarks>
-    [PublicAPI]
     public interface ISettingsService : IReadOnlySettingsService
     {
         /// <summary>
@@ -36,10 +34,10 @@ namespace phirSOFT.SettingsService.Abstractions
         /// <param name="type">The type of the setting.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         Task RegisterSettingAsync(
-            [NotNull] string key,
-            [CanBeNull] object defaultValue,
-            [CanBeNull] object initialValue,
-            [NotNull] Type type);
+            string key,
+            object? defaultValue,
+            object? initialValue,
+            Type type);
 
         /// <summary>
         ///     Sets a setting to a new value.
@@ -48,7 +46,7 @@ namespace phirSOFT.SettingsService.Abstractions
         /// <param name="value">he value of the setting.</param>
         /// <param name="type">The type of the setting.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        Task SetSettingAsync([NotNull] string key, [CanBeNull] object value, [NotNull] Type type);
+        Task SetSettingAsync(string key, object? value, Type type);
 
         /// <summary>
         ///     Stores all settings to disc.
@@ -61,6 +59,6 @@ namespace phirSOFT.SettingsService.Abstractions
         /// </summary>
         /// <param name="key">The key of the setting to unregister.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        Task UnregisterSettingAsync([NotNull] string key);
+        Task UnregisterSettingAsync(string key);
     }
 }

--- a/phirSOFT.SettingsService.Abstractions/phirSOFT.SettingsService.Abstractions.csproj
+++ b/phirSOFT.SettingsService.Abstractions/phirSOFT.SettingsService.Abstractions.csproj
@@ -51,7 +51,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="JetBrains.Annotations" Version="2019.1.3" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/phirSOFT.SettingsService/CachedSettingsService.cs
+++ b/phirSOFT.SettingsService/CachedSettingsService.cs
@@ -8,7 +8,6 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using JetBrains.Annotations;
 using Nito.AsyncEx;
 using phirSOFT.SettingsService.Abstractions;
 using CacheEntry = Nito.AsyncEx.AsyncLazy<(object value, System.Type type)>;
@@ -20,7 +19,6 @@ namespace phirSOFT.SettingsService
     ///     Implements a settings service, that will minimize the calls to the
     ///     inheriting settings service. All calls are managed thread safe.
     /// </summary>
-    [PublicAPI]
     public abstract class CachedSettingsService : ISettingsService
     {
         private readonly SortedSet<string> _changedKeys = new SortedSet<string>();
@@ -50,7 +48,7 @@ namespace phirSOFT.SettingsService
         protected abstract bool SupportConcurrentUpdate { get; }
 
         /// <inheritdoc/>
-        public async Task<object> GetSettingAsync(string key, Type type)
+        public async Task<object?> GetSettingAsync(string key, Type type)
         {
             using (await _readerWriterLock.ReaderLockAsync().ConfigureAwait(false))
             {
@@ -167,15 +165,14 @@ namespace phirSOFT.SettingsService
         /// <param name="key">The key of the setting.</param>
         /// <param name="type">The type of the setting.</param>
         /// <returns>The setting with the given key.</returns>
-        [ItemCanBeNull]
-        protected abstract Task<object> GetSettingInternalAsync([NotNull] string key, [NotNull] Type type);
+        protected abstract Task<object?> GetSettingInternalAsync(string key, Type type);
 
         /// <summary>
         ///     Gets whether a setting with the given key in known to the actual settings service.
         /// </summary>
         /// <param name="key">The key of the setting, to determine, whether it is registered.</param>
         /// <returns>A task containing the query result.</returns>
-        protected abstract Task<bool> IsRegisteredInternalAsync([NotNull] string key);
+        protected abstract Task<bool> IsRegisteredInternalAsync(string key);
 
         /// <summary>
         ///     Performs the actual settings registration.
@@ -186,10 +183,10 @@ namespace phirSOFT.SettingsService
         /// <param name="type">The type of the property.</param>
         /// <returns>A task, that finished when the new settings has been registered.</returns>
         protected abstract Task RegisterSettingInternalAsync(
-            [NotNull] string key,
-            [CanBeNull] object defaultValue,
-            [CanBeNull] object initialValue,
-            [NotNull] Type type);
+            string key,
+            object? defaultValue,
+            object? initialValue,
+            Type type);
 
         /// <summary>
         ///     Performs the actual set operation.
@@ -199,9 +196,9 @@ namespace phirSOFT.SettingsService
         /// <param name="type">The type of the setting.</param>
         /// <returns>A task that finished, when the value has been set.</returns>
         protected abstract Task SetSettingInternalAsync(
-            [NotNull] string key,
-            [CanBeNull] object value,
-            [NotNull] Type type);
+            string key,
+            object? value,
+            Type type);
 
         /// <summary>
         ///     Performs the actual store operation.
@@ -214,9 +211,9 @@ namespace phirSOFT.SettingsService
         /// </summary>
         /// <param name="key">The key of the property to unregister.</param>
         /// <returns>A task, that finished when the new settings has been unregistered.</returns>
-        protected abstract Task UnregisterSettingInternalAsync([NotNull] string key);
+        protected abstract Task UnregisterSettingInternalAsync(string key);
 
-        private async Task<(object, Type)> ConstructCacheEntry([NotNull] string key, [NotNull] Type type)
+        private async Task<(object?, Type)> ConstructCacheEntry(string key, Type type)
         {
             object value = await GetSettingInternalAsync(key, type).ConfigureAwait(false);
             return (value, type);

--- a/phirSOFT.SettingsService/ReadOnlySettingsService.cs
+++ b/phirSOFT.SettingsService/ReadOnlySettingsService.cs
@@ -5,7 +5,6 @@
 
 using System;
 using System.Threading.Tasks;
-using JetBrains.Annotations;
 using phirSOFT.SettingsService.Abstractions;
 
 namespace phirSOFT.SettingsService
@@ -22,13 +21,13 @@ namespace phirSOFT.SettingsService
         /// </summary>
         /// <param name="service">The service to wrap.</param>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="service"/> is <see langword="null"/>.</exception>
-        public ReadOnlySettingsService([NotNull] IReadOnlySettingsService service)
+        public ReadOnlySettingsService(IReadOnlySettingsService service)
         {
             _service = service ?? throw new ArgumentNullException(nameof(service));
         }
 
         /// <inheritdoc/>
-        public Task<object> GetSettingAsync(string key, Type type)
+        public Task<object?> GetSettingAsync(string key, Type type)
         {
             return _service.GetSettingAsync(key, type);
         }

--- a/phirSOFT.SettingsService/ReadOnlySettingsStack.cs
+++ b/phirSOFT.SettingsService/ReadOnlySettingsStack.cs
@@ -7,7 +7,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Threading.Tasks;
-using JetBrains.Annotations;
 using phirSOFT.SettingsService.Abstractions;
 
 namespace phirSOFT.SettingsService
@@ -16,7 +15,6 @@ namespace phirSOFT.SettingsService
     ///     Provides a <see cref="IReadOnlySettingsService"/>, that retrieves it settings from multiple sources. The first
     ///     <see cref="IReadOnlySettingsService"/>, that contains the setting, will be used.
     /// </summary>
-    [PublicAPI]
     public class ReadOnlySettingsStack : Collection<IReadOnlySettingsService>, IReadOnlySettingsService
     {
         /// <summary>
@@ -24,7 +22,7 @@ namespace phirSOFT.SettingsService
         ///     <see cref="IReadOnlySettingsService"/>s.
         /// </summary>
         /// <param name="settingsServices">The initial set of <see cref="T:phirSOFT.SettingsService.IReadOnlySettingsService"/>s.</param>
-        public ReadOnlySettingsStack([NotNull] [ItemNotNull] IEnumerable<IReadOnlySettingsService> settingsServices)
+        public ReadOnlySettingsStack(IEnumerable<IReadOnlySettingsService> settingsServices)
         {
             if (settingsServices == null)
                 throw new ArgumentNullException(nameof(settingsServices));
@@ -41,7 +39,7 @@ namespace phirSOFT.SettingsService
         }
 
         /// <inheritdoc/>
-        public async Task<object> GetSettingAsync(string key, Type type)
+        public async Task<object?> GetSettingAsync(string key, Type type)
         {
             IReadOnlySettingsService settingsService = await TryGetSettingService(key).ConfigureAwait(false);
 
@@ -68,8 +66,7 @@ namespace phirSOFT.SettingsService
         ///     <see cref="IReadOnlySettingsService"/>, that contains the requested key, or <see langword="null"/>, if not
         ///     <see cref="IReadOnlySettingsService"/> contained the <paramref name="key"/>.
         /// </returns>
-        [ItemCanBeNull]
-        protected async Task<IReadOnlySettingsService> TryGetSettingService(string key)
+        protected async Task<IReadOnlySettingsService?> TryGetSettingService(string key)
         {
             using (IEnumerator<IReadOnlySettingsService> enumerator = GetEnumerator())
             {

--- a/phirSOFT.SettingsService/SettingsService.cs
+++ b/phirSOFT.SettingsService/SettingsService.cs
@@ -6,7 +6,6 @@
 using System;
 using System.Reflection;
 using System.Threading.Tasks;
-using JetBrains.Annotations;
 using phirSOFT.SettingsService.Abstractions;
 using static phirSOFT.SettingsService.TypeHelper;
 
@@ -15,7 +14,6 @@ namespace phirSOFT.SettingsService
     /// <summary>
     ///     Provides extension methods for an <see cref="ISettingsService"/>.
     /// </summary>
-    [PublicAPI]
     public static class SettingsService
     {
         /// <summary>
@@ -24,8 +22,7 @@ namespace phirSOFT.SettingsService
         /// <param name="service">The service to wrap.</param>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="service"/> is <see langword="null"/>.</exception>
         /// <returns>A pure read only settings service.</returns>
-        [NotNull]
-        public static IReadOnlySettingsService AsReadOnly([NotNull] this IReadOnlySettingsService service)
+        public static IReadOnlySettingsService AsReadOnly(this IReadOnlySettingsService service)
         {
             if (service == null)
                 throw new ArgumentNullException(nameof(service));
@@ -44,10 +41,9 @@ namespace phirSOFT.SettingsService
         ///     <see langword="null"/>.
         /// </exception>
         /// <returns>The value of the setting, if its present in this service.</returns>
-        [ItemCanBeNull]
         public static async Task<T> GetSettingAsync<T>(
-            [NotNull] this IReadOnlySettingsService service,
-            [NotNull] string key)
+            this IReadOnlySettingsService service,
+            string key)
         {
             if (service == null)
                 throw new ArgumentNullException(nameof(service));
@@ -69,7 +65,7 @@ namespace phirSOFT.SettingsService
         ///     <see langword="null"/>.
         /// </exception>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        public static Task RegisterSettingAsync<T>([NotNull] this ISettingsService service, [NotNull] string key)
+        public static Task RegisterSettingAsync<T>(this ISettingsService service, string key)
         {
             if (service == null)
                 throw new ArgumentNullException(nameof(service));
@@ -95,9 +91,9 @@ namespace phirSOFT.SettingsService
         /// </exception>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public static Task RegisterSettingAsync(
-            [NotNull] this ISettingsService service,
-            [NotNull] string key,
-            [NotNull] Type type)
+            this ISettingsService service,
+            string key,
+            Type type)
         {
             if (service == null)
                 throw new ArgumentNullException(nameof(service));
@@ -126,9 +122,9 @@ namespace phirSOFT.SettingsService
         /// </exception>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public static Task RegisterSettingAsync<T>(
-            [NotNull] this ISettingsService service,
-            [NotNull] string key,
-            [CanBeNull] T defaultValue)
+            this ISettingsService service,
+            string key,
+            T defaultValue)
         {
             if (service == null)
                 throw new ArgumentNullException(nameof(service));
@@ -154,9 +150,9 @@ namespace phirSOFT.SettingsService
         /// </exception>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public static Task RegisterSettingAsync(
-            [NotNull] this ISettingsService service,
-            [NotNull] string key,
-            [CanBeNull] object defaultValue)
+            this ISettingsService service,
+            string key,
+            object? defaultValue)
         {
             if (service == null)
                 throw new ArgumentNullException(nameof(service));
@@ -184,10 +180,10 @@ namespace phirSOFT.SettingsService
         /// </exception>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public static Task RegisterSettingAsync(
-            [NotNull] this ISettingsService service,
-            [NotNull] string key,
-            [CanBeNull] object defaultValue,
-            [NotNull] Type type)
+            this ISettingsService service,
+            string key,
+            object? defaultValue,
+            Type type)
         {
             if (service == null)
                 throw new ArgumentNullException(nameof(service));
@@ -215,10 +211,10 @@ namespace phirSOFT.SettingsService
         /// </exception>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public static Task RegisterSettingAsync<T>(
-            [NotNull] this ISettingsService service,
-            [NotNull] string key,
-            [CanBeNull] T defaultValue,
-            [CanBeNull] T initialValue)
+            this ISettingsService service,
+            string key,
+            T defaultValue,
+            T initialValue)
         {
             if (service == null)
                 throw new ArgumentNullException(nameof(service));
@@ -245,10 +241,10 @@ namespace phirSOFT.SettingsService
         /// </exception>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public static Task RegisterSettingAsync(
-            [NotNull] this ISettingsService service,
-            [NotNull] string key,
-            object defaultValue,
-            object initialValue)
+            this ISettingsService service,
+            string key,
+            object? defaultValue,
+            object? initialValue)
         {
             if (service == null)
                 throw new ArgumentNullException(nameof(service));
@@ -284,9 +280,9 @@ namespace phirSOFT.SettingsService
         /// </exception>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public static Task SetSettingAsync<T>(
-            [NotNull] this ISettingsService service,
-            [NotNull] string key,
-            [CanBeNull] T value)
+            this ISettingsService service,
+            string key,
+            T value)
         {
             if (service == null)
                 throw new ArgumentNullException(nameof(service));
@@ -312,9 +308,9 @@ namespace phirSOFT.SettingsService
         /// </exception>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public static Task SetSettingAsync(
-            [NotNull] this ISettingsService service,
-            [NotNull] string key,
-            [CanBeNull] object value)
+            this ISettingsService service,
+            string key,
+            object? value)
         {
             if (service == null)
                 throw new ArgumentNullException(nameof(service));

--- a/phirSOFT.SettingsService/SettingsStack.cs
+++ b/phirSOFT.SettingsService/SettingsStack.cs
@@ -7,7 +7,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using JetBrains.Annotations;
 using phirSOFT.SettingsService.Abstractions;
 
 namespace phirSOFT.SettingsService
@@ -16,7 +15,6 @@ namespace phirSOFT.SettingsService
     /// <summary>
     ///     Provides a settings service that retrieves settings from multiple sources.
     /// </summary>
-    [PublicAPI]
     public class SettingsStack : ReadOnlySettingsStack, ISettingsService
     {
         /// <summary>
@@ -26,8 +24,8 @@ namespace phirSOFT.SettingsService
         /// <param name="writableSettingsService">The <see cref="ISettingsService"/>, that changes should be written to.</param>
         /// <param name="settingsServices">The initial set of <see cref="T:phirSOFT.SettingsService.IReadOnlySettingsService"/>s.</param>
         public SettingsStack(
-            [NotNull] ISettingsService writableSettingsService,
-            [NotNull] [ItemNotNull] IEnumerable<IReadOnlySettingsService> settingsServices)
+            ISettingsService writableSettingsService,
+            IEnumerable<IReadOnlySettingsService> settingsServices)
             : base(settingsServices)
         {
             WritableService = writableSettingsService;
@@ -37,7 +35,7 @@ namespace phirSOFT.SettingsService
         ///     Initializes a new instance of the <see cref="SettingsStack"/> class.
         /// </summary>
         /// <param name="writableSettingsService">The <see cref="ISettingsService"/>, that changes should be written to.</param>
-        public SettingsStack([NotNull] ISettingsService writableSettingsService)
+        public SettingsStack(ISettingsService writableSettingsService)
             : this(writableSettingsService, Enumerable.Empty<IReadOnlySettingsService>())
         {
         }
@@ -45,7 +43,6 @@ namespace phirSOFT.SettingsService
         /// <summary>
         ///     Gets or sets the <see cref="ISettingsService"/>, that is used to write settings.
         /// </summary>
-        [NotNull]
         public ISettingsService WritableService { get; set; }
 
         /// <inheritdoc/>

--- a/phirSOFT.SettingsService/TypeHelper.cs
+++ b/phirSOFT.SettingsService/TypeHelper.cs
@@ -5,8 +5,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
-using JetBrains.Annotations;
 
 namespace phirSOFT.SettingsService
 {
@@ -36,8 +36,7 @@ namespace phirSOFT.SettingsService
         ///     <see langword="true"/>, if <paramref name="typeA"/> can be assigned to <paramref name="typeB"/> or the other
         ///     way around.
         /// </returns>
-        [ContractAnnotation("=> true,type:notnull; => false,type:null")]
-        internal static bool AreAssignable([NotNull] TypeInfo typeA, [NotNull] TypeInfo typeB, out Type type)
+        internal static bool AreAssignable(TypeInfo typeA, TypeInfo typeB, [MaybeNullWhen(false)] out Type type)
         {
             type = null;
 
@@ -62,8 +61,7 @@ namespace phirSOFT.SettingsService
         ///     </para>
         /// </remarks>
         /// <returns>The default value of the type.</returns>
-        [CanBeNull]
-        internal static object GetDefaultValue([NotNull] Type type)
+        internal static object? GetDefaultValue([NotNull] Type type)
         {
             return type.GetTypeInfo().IsValueType ? Activator.CreateInstance(type) : null;
         }
@@ -78,8 +76,7 @@ namespace phirSOFT.SettingsService
         ///     <see langword="true"/>, if <paramref name="typeA"/> and <paramref name="typeB"/> share a common base class
         ///     other than <see cref="object"/>.
         /// </returns>
-        [ContractAnnotation("=> true,type:notnull; => false,type:null")]
-        internal static bool HaveCommonBaseType([NotNull] TypeInfo typeA, [NotNull] TypeInfo typeB, out Type type)
+        internal static bool HaveCommonBaseType(TypeInfo typeA, TypeInfo typeB, [MaybeNullWhen(false)] out Type type)
         {
             Queue<TypeInfo> typeChainA = GetTypeChain(typeA);
             Queue<TypeInfo> typeChainB = GetTypeChain(typeB);
@@ -100,9 +97,7 @@ namespace phirSOFT.SettingsService
             return false;
         }
 
-        [NotNull]
-        [ItemNotNull]
-        private static Queue<TypeInfo> GetTypeChain([NotNull] TypeInfo type)
+        private static Queue<TypeInfo> GetTypeChain(TypeInfo type)
         {
             var chain = new Queue<TypeInfo>();
 

--- a/phirSOFT.SettingsService/phirSOFT.SettingsService.csproj
+++ b/phirSOFT.SettingsService/phirSOFT.SettingsService.csproj
@@ -45,6 +45,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Nito.AsyncEx.Coordination" Version="5.0.0" />
+    <PackageReference Include="Nullable" Version="1.2.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Use the C# 8.0 Annotations to declare nullability instead of resharper
annotations.